### PR TITLE
fix ui issue with overlapping dropdowns from hero page filters

### DIFF
--- a/assets/scss/epicsevendb.scss
+++ b/assets/scss/epicsevendb.scss
@@ -1280,6 +1280,10 @@ aside.column {
         cursor: pointer;
     }
 
+    div:nth-of-type(5) .is-multiselect-container {
+        z-index: 8;
+    }
+
     @include tablet {
         .toggleable-btns .column {
             &:first-child {
@@ -1288,6 +1292,11 @@ aside.column {
             &:last-child {
                 padding-left: 0.5rem;
             }
+        }
+    }
+    @include mobile {
+        div:nth-of-type(4) .is-multiselect-container:last-child {
+            z-index: 9;
         }
     }
 }


### PR DESCRIPTION
implemented a hacky fix for now, but issue stems from the multiselect dropdowns having the same z-index (10), am open for suggestions on a more versatile fix

* SS (Desktop):
![Capture](https://user-images.githubusercontent.com/41027303/67157035-ed101000-f2eb-11e9-87ac-ee1414776002.PNG)

* SS (Tablet):
![Capture3](https://user-images.githubusercontent.com/41027303/67157039-fac59580-f2eb-11e9-9e91-809c6a05db49.PNG)

Note:  this issue still persists on tablet view when the select content opens upward (from being on a lower position in the view)
